### PR TITLE
Fix TS2307: Cannot find module 'ng2-select' error

### DIFF
--- a/demo/src/app/app.module.ts
+++ b/demo/src/app/app.module.ts
@@ -4,7 +4,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common';
 import { TabsModule, ButtonsModule } from 'ngx-bootstrap';
 
-import { SelectModule } from 'ng2-select';
+import { SelectModule } from 'ng2-select/src';
 import { AppComponent } from './app.component';
 import { SelectSectionComponent } from './components/select-section';
 import { ChildrenDemoComponent } from './components/select/children-demo';


### PR DESCRIPTION
Fixes `ERROR in node_modules/ng2-select/demo/src/app/app.module.ts(7,30): error TS2307: Cannot find module 'ng2-select'.`